### PR TITLE
Add mkdocs-material theme and dark theme toggle

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs
+      - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force --verbose

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,20 @@ nav:
       - 'Make the moon': 'MOON.md'
 
 theme:
-  name: readthedocs
+  name: material
+  palette: 
+    # Palette toggle for light mode
+    - scheme: default
+      toggle:
+        icon: material/brightness-7 
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+        
   highlightjs: true
   hljs_languages:
     - yaml


### PR DESCRIPTION
This  replaces the default `mkdocs` theme with the [mkdocs material](https://squidfunk.github.io/mkdocs-material/) theme. Additionally, enables theme toggling as documented [here](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle). Might consider defaulting to light theme. 🤷‍♂️